### PR TITLE
References

### DIFF
--- a/eregs_core/templates/paragraph.html
+++ b/eregs_core/templates/paragraph.html
@@ -1,6 +1,3 @@
-{% load marker %}
-
-<a href="#{{ node.label }}"></a>
 {% if node.children.0.tag == "title" %}
     <h5><em class="paragraph-marker">{{ node.attributes.marker }}</em>
         {% if node.has_diff_title %}

--- a/eregs_core/templates/reference.html
+++ b/eregs_core/templates/reference.html
@@ -4,8 +4,8 @@
     <a href="{{ child.target }}" class="citation definition"
        data-definition="{{ child.target }}">{{ child.regtext }}</a>
 {% elif child.reftype == "internal" %}
-    <a href="{{ child.target }}" class="citation internal"
-       data-section-id="{{ child.target }}">{{ child.regtext }}</a>
+    <a href="{{ child.target_url }}" class="citation internal"
+       data-section-id="{{ child.target}}">{{ child.regtext }}</a>
 {% elif child.reftype == "external" %}
     <a href="{{ child.target }}" class="citation external"
        data-section-id="{{ child.target }}">{{ child.regtext }}</a>

--- a/eregs_core/templates/regnode.html
+++ b/eregs_core/templates/regnode.html
@@ -62,7 +62,8 @@
         {% with node=child template_name="regnode.html" %}
             {% with marker=node.marker_type %}
                 {% if not node.tag == "appendixSection" %}
-                    <li {% if marker == "none" or marker == None or marker == '' %}class="markerless"{% endif %} >
+                    <li {% if marker == "none" or marker == None or marker == '' %}class="markerless"{% endif %}
+                            id="{{ node.label }}">
                         {% include template_name %}</li>
                 {% else %}
                     {% include template_name %}

--- a/eregs_core/templates/regnode.html
+++ b/eregs_core/templates/regnode.html
@@ -19,7 +19,7 @@
 
     {% elif node.tag == "appendix" %}
         <section id="{{ node.label }}" class="appendix-section section-focus content-{{ node.label }}"
-                 data-base-version="{{ meta.document_number }}"
+                 data-base-version="{{ meta.document_number }}" data-effective-date="{{ meta.effective_date }}"
                  data-page-type="appendix">
             <h2 class="appendix-title" tabindex="0">
                 {{ node.children.0.children.0.text }}
@@ -27,7 +27,7 @@
 
     {% elif node.tag == "interpretations" %}
         <section id="{{ node.label }}" class="supplement-section" data-base-version="{{ meta.document_number }}"
-                 data-page-type="interpretation">
+                 data-page-type="interpretation" data-effective-date="{{ meta.effective_date }}">
 
     {% elif node.tag == "interpSection" %}
         <section id="{{ node.label }}" data-permalink-section>

--- a/eregs_core/views.py
+++ b/eregs_core/views.py
@@ -57,10 +57,9 @@ def regulation_partial(request, version, eff_date, node):
         regtext.get_descendants()
 
         if regtext is not None and meta is not None:
-            result = render_to_string('regnode.html', {'node': regtext,
+            return render_to_response('regnode.html', {'node': regtext,
+                                                       'mode': 'reg',
                                                        'meta': meta})
-            result = '<section id="content-wrapper" class="reg-text">' + result + '</section>'
-            return HttpResponse(result)
 
 
 def diff(request, left_version, left_eff_date, right_version, right_eff_date, node):

--- a/eregs_core/views.py
+++ b/eregs_core/views.py
@@ -57,9 +57,11 @@ def regulation_partial(request, version, eff_date, node):
         regtext.get_descendants()
 
         if regtext is not None and meta is not None:
-            return render_to_response('regnode.html', {'node': regtext,
+            result = render_to_string('regnode.html', {'node': regtext,
                                                        'mode': 'reg',
                                                        'meta': meta})
+            result = '<section id="content-wrapper" class="reg-text">' + result + '</section>'
+            return HttpResponse(result)
 
 
 def diff(request, left_version, left_eff_date, right_version, right_eff_date, node):


### PR DESCRIPTION
This PR fixes the broken `data-effective-date` attributes on the interp and appendix section headers. It also fixes navigation anchors for individual paragraphs and adds functionality to retrieve ancestors for a given node, as well as for the proper construction of URLs that point to internal references.