### PR TITLE
Update client-side routes to match new URL formats

### DIFF
--- a/eregs_core/static/regulations/js/source/models/meta-model.js
+++ b/eregs_core/static/regulations/js/source/models/meta-model.js
@@ -113,31 +113,27 @@ var MetaModel = Backbone.Model.extend({
             urlPrefix = window.APP_PREFIX;
 
         if (urlPrefix) {
-            url = urlPrefix + 'partial/';
+            url = urlPrefix + 'partial';
         }
         else {
-            url = '/partial/';
+            url = '/partial';
         }
 
         if (typeof this.supplementalPath !== 'undefined') {
-            url += this.supplementalPath + '/';
+            url += '/' + this.supplementalPath;
         }
 
-        //url += id;
         console.log('url stub: ', url)
 
         if (id.indexOf('/') === -1) {
-            url += Helpers.findVersion(Resources.versionElements);
+            url += '/' + Helpers.findVersion(Resources.versionElements);
             url += '/' + Helpers.findEffDate(Resources.versionElements);
         }
         console.log('id: ', id);
         console.log('version: ', Helpers.findVersion(Resources.versionElements));
         console.log('eff date: ', Helpers.findEffDate(Resources.versionElements));
-        if (url.endsWith('/')) {
-            url += id;
-        } else {
-            url += '/' + id;
-        }
+
+        url += '/' + id;
 
         console.log('target url: ' + url)
         return url;

--- a/eregs_core/static/regulations/js/source/router.js
+++ b/eregs_core/static/regulations/js/source/router.js
@@ -18,15 +18,14 @@ if (typeof window.history.pushState === 'undefined') {
 else {
     RegsRouter = Backbone.Router.extend({
         routes: {
-            'sxs/:section/:version': 'loadSxS',
+            'sxs/:version/:effectiveDate/:node': 'loadSxS',
             'search/:reg': 'loadSearchResults',
             'diff/:section/:baseVersion/:newerVersion': 'loadDiffSection',
-            ':section/:version': 'loadSection'
+            'regulation/:version/:date/:node': 'loadSection'
         },
 
-        loadSection: function(section, version) {
-            var options = {id: section};
-            console.log(section + ' ' + version)
+        loadSection: function(version, date, node) {
+            var options = {id: node};
 
             // to scroll to paragraph if there is a hadh
             options.scrollToId = Backbone.history.getHash();
@@ -34,7 +33,7 @@ else {
             // ask the view not to route, its not needed
             options.noRoute = true;
 
-            MainEvents.trigger('section:open', section, options, 'reg-section');
+            MainEvents.trigger('section:open', node, options, 'reg-section');
         },
 
         loadDiffSection: function(section, baseVersion, newerVersion, params) {

--- a/eregs_core/templates/right_sidebar.html
+++ b/eregs_core/templates/right_sidebar.html
@@ -1,7 +1,7 @@
 <div id="sidebar" class="secondary-content" role="complementary">
     <div id="sidebar-content" class="sidebar-inner">
         <section id="definition"></section>
-        <section id="sxs-list" class="regs-meta" data-foo="foo">
+        <section id="sxs-list" class="regs-meta">
             <header id="sxs-expandable-header" class="expandable sxs-expand group has-content" data-expandable="sxs-expandable">
                 <h4 tabindex="0">Section-by-section Analysis</h4>
                 <a href="#" tabindex="0"><span class="icon-text">Show/Hide Contents</span></a>


### PR DESCRIPTION
It turns out a handful of our navigation irregularities are caused by old Backbone routes. This PR updates the regulation and SXS routes. We may need to update the search and diff routes at some point.

Fixes #8.