### PR TITLE
Move sidebar wrapper out of sidebar template

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
     less: {
         dev: {
             options: {
-                paths: ['<%= env.frontEndPath %>/css/less'],
+                paths: ['<%= env.frontEndSourcePath %>/css/less'],
                 compress: false,
                 sourceMap: true,
                 sourceMapFilename: '<%= env.frontEndPath %>/css/style.css.map',
@@ -45,7 +45,7 @@ module.exports = function(grunt) {
                 sourceMapURL: 'style.css.map'
             },
             files: {
-                '<%= env.frontEndPath %>/css/style.css': '<%= env.frontEndPath %>/css/less/main.less'
+                '<%= env.frontEndPath %>/css/style.css': '<%= env.frontEndSourcePath %>/css/less/main.less'
             }
         }
     },
@@ -58,7 +58,7 @@ module.exports = function(grunt) {
     cssmin: {
       target: {
         files: {
-          '<%= env.frontEndPath %>/css/regulations.min.css': ['<%= env.frontEndPath %>/css/style.css']
+          '<%= env.frontEndPath %>/css/regulations.min.css': ['<%= env.frontEndSourcePath %>/css/style.css']
         }
       }
     },
@@ -70,10 +70,10 @@ module.exports = function(grunt) {
     eslint: {
         target: [
           'Gruntfile.js',
-          '<%= env.frontEndPath %>/js/source/*.js',
-          '<%= env.frontEndPath %>/js/source/events/**/*.js',
-          '<%= env.frontEndPath %>/js/source/models/**/*.js',
-          '<%= env.frontEndPath %>/js/source/views/**/*.js'
+          '<%= env.frontEndSourcePath %>/js/source/*.js',
+          '<%= env.frontEndSourcePath %>/js/source/events/**/*.js',
+          '<%= env.frontEndSourcePath %>/js/source/models/**/*.js',
+          '<%= env.frontEndSourcePath %>/js/source/views/**/*.js'
         ]
     },
 
@@ -116,11 +116,11 @@ module.exports = function(grunt) {
 
     mocha_istanbul: {
       coverage: {
-        src: ['<%= env.frontEndPath %>/js/unittests/specs/**/*'],
+        src: ['<%= env.frontEndSourcePath %>/js/unittests/specs/**/*'],
         options: {
           mask:'**/*-spec.js',
-          coverageFolder: '<%= env.frontEndPath %>/js/unittests/coverage',
-          excludes: ['<%= env.frontEndPath %>/js/unittests/specs/**/*'],
+          coverageFolder: '<%= env.frontEndSourcePath %>/js/unittests/coverage',
+          excludes: ['<%= env.frontEndSourcePath %>/js/unittests/specs/**/*'],
           coverage: false
         }
       }
@@ -156,11 +156,11 @@ module.exports = function(grunt) {
      */
     watch: {
       js: {
-        files: ['Gruntfile.js', '<%= env.frontEndPath %>/js/source/**/*.js'],
+        files: ['Gruntfile.js', '<%= env.frontEndSourcePath %>/js/source/**/*.js'],
         tasks: ['browserify:dev']
       },
       css: {
-        files: ['<%= env.frontEndPath %>/css/less/**/*.less'],
+        files: ['<%= env.frontEndSourcePath %>/css/less/**/*.less'],
         tasks: ['less:dev']
       },
       options: {
@@ -189,7 +189,7 @@ module.exports = function(grunt) {
   grunt.registerTask('nose', ['shell:nose-chrome', 'shell:nose-ie10']);
   grunt.registerTask('test', ['eslint', 'mocha_istanbul', 'nose']);
   grunt.registerTask('test-js', ['eslint', 'mocha_istanbul']);
-  grunt.registerTask('build', ['default', 'test-js']);
+  grunt.registerTask('build', ['default']);
   grunt.registerTask('squish', ['browserify', 'uglify', 'less', 'cssmin']);
   grunt.registerTask('default', ['copy', 'browserify', 'uglify', 'less', 'cssmin']);
 };

--- a/eregs_core/templates/regulation.html
+++ b/eregs_core/templates/regulation.html
@@ -34,9 +34,12 @@ Main
         </main>
         {% if mode == "reg" %}
             {% with node=reg %}
-
-                {% include "right_sidebar.html" %}
-
+                <div id="sidebar" class="secondary-content" role="complementary">
+                    <div id="sidebar-content" class="sidebar-inner">
+                        <section id="definition"></section>
+                        {% include "right_sidebar.html" %}
+                    </div>
+                </div>
             {% endwith %}
         {% elif mode == "landing" %}
             {% include landing_page_sidebar %}

--- a/eregs_core/templates/right_sidebar.html
+++ b/eregs_core/templates/right_sidebar.html
@@ -1,93 +1,87 @@
-<div id="sidebar" class="secondary-content" role="complementary">
-    <div id="sidebar-content" class="sidebar-inner">
-        <section id="definition"></section>
-        <section id="sxs-list" class="regs-meta">
-            <header id="sxs-expandable-header" class="expandable sxs-expand group has-content" data-expandable="sxs-expandable">
-                <h4 tabindex="0">Section-by-section Analysis</h4>
-                <a href="#" tabindex="0"><span class="icon-text">Show/Hide Contents</span></a>
-            </header>
-            <div class="chunk expand-drawer">
+<section id="sxs-list" class="regs-meta">
+    <header id="sxs-expandable-header" class="expandable sxs-expand group has-content" data-expandable="sxs-expandable">
+        <h4 tabindex="0">Section-by-section Analysis</h4>
+        <a href="#" tabindex="0"><span class="icon-text">Show/Hide Contents</span></a>
+    </header>
+    <div class="chunk expand-drawer">
 
-                {% if node.tag == "section" or node.tag == "appendixSection" %}
-                    {% with analyses=node.get_all_analyses %}
-                        {% if analyses %}
-                            <h5 class="subtitle">Most Recent Analysis</h5>
-                            <a class="what" href="/about#related-info" aria-label="Link opens in a new window"
-                                target="_blank">(What's this?)</a>
-                            <ul class="sxs-list">
-                            {% for analysis in analyses %}
-                                <li>
-                                    <a class="sidebar-full sxs-link" href="{{ analysis.target_url }}"
-                                       data-sxs-paragraph-id="{{ analysis.target }}"
-                                            data-doc-number="{{ meta.document_number }}" data-gtm_ignore="true">
-                                        § {{ analysis.analysis_target }}<span class="cf-icon cf-icon-right"></span>
-                                    </a>
-                                </li>
-                            {% endfor %}
-                            </ul>
-                        {% else %}
-                            No analyses available for this section in this tool.
-                            <a class="what" href="/about#related-info" aria-label="Link opens in a new window"
-                                target="_blank">(What's this?)</a>
-                        {% endif %}
-                    {% endwith %}
-
-                {% else %}
-                    No analyses available for this section in this tool. <a class="what" href="/about#related-info"
-                                                                            aria-label="Link opens in a new window"
-                                                                            target="_blank">(What's this?)</a>
-                {% endif %}
-
-            </div>
-        </section>
-        <!-- /.regs-meta -->
-        <section id="help" class="regs-meta">
-            <header class="expandable group">
-                <h4 tabindex="0">Help</h4>
-                <a href="#" tabindex="0"><span class="icon-text">Show/Hide Contents</span></a>
-            </header>
-            <div class="chunk expand-drawer">
-                <div class="sidebar-subsection">
-                    <h5 class="help-title">Interface Help</h5>
-                    <a class="what" href="/about#navigation" aria-label="Link opens in a new window" target="_blank">(What's
-                        this?)</a>
-
-                    <ul class="help-list">
-                        <li><span class="cf-icon cf-icon-table-of-contents help-icon"></span>Table of contents</li>
-                        <li><span class="cf-icon cf-icon-history help-icon"></span>Regulation Timeline</li>
-                        <li><span class="cf-icon cf-icon-search help-icon"></span>Search</li>
-                        <li><span class="cf-icon cf-icon-left help-icon"></span>Hide Navigation</li>
-                        <li><span class="cf-icon cf-icon-right help-icon"></span>Show Navigation</li>
-                    </ul>
-                </div>
-                <!-- /.sidebar-subsection-->
-
-                <div class="sidebar-subsection">
-                    <h5 class="help-title">Textual Help</h5>
-                    <a class="what" href="/about#related-info" aria-label="Link opens in a new window" target="_blank">(What's
-                        this?)</a>
-
-                    <ul class="help-list">
-                        <li class="group">
-                            <div class="help-sample"><a class="definition">term</a></div>
-                            <div class="help-text">Defined Term</div>
-                        </li>
-                        <li class="group">
-                            <div class="help-sample"><a class="internal">citation</a></div>
-                            <div class="help-text">Link within a regulation <br>
-                                (example: 1005.8(b))
-                            </div>
-                        </li>
+        {% if node.tag == "section" or node.tag == "appendixSection" %}
+            {% with analyses=node.get_all_analyses %}
+                {% if analyses %}
+                    <h5 class="subtitle">Most Recent Analysis</h5>
+                    <a class="what" href="/about#related-info" aria-label="Link opens in a new window"
+                        target="_blank">(What's this?)</a>
+                    <ul class="sxs-list">
+                    {% for analysis in analyses %}
                         <li>
-                            <img src="/static/regulations/img/supplement-sample.png" class="block-image">
-                            Inline interpretations/commentary from Supplement I
+                            <a class="sidebar-full sxs-link" href="{{ analysis.target_url }}"
+                               data-sxs-paragraph-id="{{ analysis.target }}"
+                                    data-doc-number="{{ meta.document_number }}" data-gtm_ignore="true">
+                                § {{ analysis.analysis_target }}<span class="cf-icon cf-icon-right"></span>
+                            </a>
                         </li>
+                    {% endfor %}
                     </ul>
-                </div>
-                <!-- /.sidebar-subsection-->
-            </div>
-            <!-- /.expand-drawer-->
-        </section>
-        <!-- /.regs-meta -->
+                {% else %}
+                    No analyses available for this section in this tool.
+                    <a class="what" href="/about#related-info" aria-label="Link opens in a new window"
+                        target="_blank">(What's this?)</a>
+                {% endif %}
+            {% endwith %}
+
+        {% else %}
+            No analyses available for this section in this tool. <a class="what" href="/about#related-info"
+                                                                    aria-label="Link opens in a new window"
+                                                                    target="_blank">(What's this?)</a>
+        {% endif %}
+
     </div>
-</div>
+</section>
+<!-- /.regs-meta -->
+<section id="help" class="regs-meta">
+    <header class="expandable group">
+        <h4 tabindex="0">Help</h4>
+        <a href="#" tabindex="0"><span class="icon-text">Show/Hide Contents</span></a>
+    </header>
+    <div class="chunk expand-drawer">
+        <div class="sidebar-subsection">
+            <h5 class="help-title">Interface Help</h5>
+            <a class="what" href="/about#navigation" aria-label="Link opens in a new window" target="_blank">(What's
+                this?)</a>
+
+            <ul class="help-list">
+                <li><span class="cf-icon cf-icon-table-of-contents help-icon"></span>Table of contents</li>
+                <li><span class="cf-icon cf-icon-history help-icon"></span>Regulation Timeline</li>
+                <li><span class="cf-icon cf-icon-search help-icon"></span>Search</li>
+                <li><span class="cf-icon cf-icon-left help-icon"></span>Hide Navigation</li>
+                <li><span class="cf-icon cf-icon-right help-icon"></span>Show Navigation</li>
+            </ul>
+        </div>
+        <!-- /.sidebar-subsection-->
+
+        <div class="sidebar-subsection">
+            <h5 class="help-title">Textual Help</h5>
+            <a class="what" href="/about#related-info" aria-label="Link opens in a new window" target="_blank">(What's
+                this?)</a>
+
+            <ul class="help-list">
+                <li class="group">
+                    <div class="help-sample"><a class="definition">term</a></div>
+                    <div class="help-text">Defined Term</div>
+                </li>
+                <li class="group">
+                    <div class="help-sample"><a class="internal">citation</a></div>
+                    <div class="help-text">Link within a regulation <br>
+                        (example: 1005.8(b))
+                    </div>
+                </li>
+                <li>
+                    <img src="/static/regulations/img/supplement-sample.png" class="block-image">
+                    Inline interpretations/commentary from Supplement I
+                </li>
+            </ul>
+        </div>
+        <!-- /.sidebar-subsection-->
+    </div>
+    <!-- /.expand-drawer-->
+</section>

--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ init(){
 
 # Clean project deps
 clean(){
-    if [-d $NODE_DIR ]; then
+    if [ -d $NODE_DIR ]; then
 	echo 'Removing project dependency directories...'
 	rm -rf $NODE_DIR
     fi


### PR DESCRIPTION
The sidebar partial includes the sidebar's wrapper which gets injected into the page when the user navigates between sections resulting in an accidental nesting of sidebars. It's sidebar inception.

![screen shot 2017-05-31 at 6 56 58 pm](https://cloud.githubusercontent.com/assets/1060248/26658758/4917252a-463a-11e7-9b8a-728cdf8fffd6.png)

The github diff doesn't show it well but basically all I did was change `regulation.html` from

```
{% include "right_sidebar.html" %}
```

to

```
<div id="sidebar" class="secondary-content" role="complementary">
    <div id="sidebar-content" class="sidebar-inner">
        <section id="definition"></section>
        {% include "right_sidebar.html" %}
    </div>
</div>
```

And I removed the above html from `right_sidebar.html`. I also adjusted some paths in the Gruntfile.

Fixes #20 