### PR TITLE
Add required elasticsearch install for haystack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ lxml
 django-haystack
 django-mysql
 django-extensions
+elasticsearch==5.4.0
 python-dateutil
 git+https://github.com/PyMySQL/mysqlclient-python.git@master


### PR DESCRIPTION
In order to use Elasticsearch with Django-Haystack, you need to have the Python elasticsearch package installed in your virtual environment. See the documentation here:

https://django-haystack.readthedocs.io/en/master/backend_support.html#id2

Without this, hitting the home page causes a 500 error with the message:

> "MissingDependency: The 'elasticsearch' backend requires the installation of 'elasticsearch'. Please refer to the documentation."

## Additions

- Adds `elasticsearch==5.4.0` to the requirements file.

## Testing

- Create a new virtual environment, install requirements, and confirm that you can hit [http://localhost:8000](http://localhost:8000) after running the Django server without error.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
