### PR TITLE
add 'cfgov_setup' to 'setup_requires'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(
     license='MIT',
     description='The new version of eRegs.',
     include_package_data=True,
+    setup_requires=['cfgov_setup==1.2',],
     frontend_build_script='setup.sh'
 )


### PR DESCRIPTION
This is what implements the "frontend_build_script" functionality (otherwise, that option does nothing)

## Additions

- add `setup_requires=['cfgov_setup==1.2',],` to setup.py


## Testing

- in a new empty directory, run `pip wheel [path-to-eregs-2.0 checkout]`. As long as your node/grunt environment is sane, it should produce a .whl file.
- unzip that whl file, and confirm that all of the static assets you  expect are present. If not, we might need to tweak MANIFEST.in

## Review

- @user

[Preview this PR without the whitespace changes](?w=0)

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
