### PR TITLE
Adds .coveragerc to properly report coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+omit =
+    .tox/*
+    */migrations/*
+    eregs/settings*
+
+
+[report]
+exclude_lines = 
+    pragma: no cover
+    if __name__ == .__main__.:
+    if .__main__. == __name__:


### PR DESCRIPTION
This change adds a `.coveragerc` file to properly report the unit testcode coverage. It omits certain directories that should not be counted (`.tox`) and those that are somewhat unrelated to unit tests
(`migrations` and `settings`).

## Additions

- Adds `.coveragerc` file.

## Testing

- To see the difference this file makes, run unit tests with `tox` and then type `coverage report` to generate the coverage report.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests