### PR TITLE
Import diff bulk insert

### DIFF
--- a/eregs_core/management/commands/import_diff.py
+++ b/eregs_core/management/commands/import_diff.py
@@ -150,5 +150,5 @@ def insert_all(node, version):
 
     recursive_insert(node, version)
 
-    RegNode.objects.bulk_create(result_nodes)
+    RegNode.objects.bulk_create(result_nodes, batch_size=100)
 

--- a/eregs_core/management/commands/import_diff.py
+++ b/eregs_core/management/commands/import_diff.py
@@ -1,14 +1,12 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.core.exceptions import ObjectDoesNotExist
-from eregs_core.models import DiffNode, Version, RegNode
+from eregs_core.models import Version, RegNode
 from eregs_core.utils import xml_diff_to_json
 from eregs_core.diffs import diff_files
 from lxml import etree
 
 import os
-import json
 import time
-import math
 
 from eregs.local_settings import DEBUG
 


### PR DESCRIPTION
This PR makes it so that `import_diff` uses a bulk insert rather than item-by-item insert to insert nodes. This is much faster.