### PR TITLE
Remove dependence on local_settings.py file

### DIFF
--- a/eregs_core/management/commands/import_diff.py
+++ b/eregs_core/management/commands/import_diff.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.core.exceptions import ObjectDoesNotExist
 from eregs_core.models import DiffNode, Version
@@ -8,8 +9,6 @@ from lxml import etree
 import os
 import json
 import time
-
-from eregs.local_settings import DEBUG
 
 
 class Command(BaseCommand):
@@ -69,7 +68,7 @@ class Command(BaseCommand):
         # part_toc = part.find('{eregs}tableOfContents')
 
         # flush the table of existing content for this reg
-        if DEBUG:
+        if settings.DEBUG:
             start_time = time.clock()
 
         try:
@@ -88,7 +87,7 @@ class Command(BaseCommand):
 
         insert_all(reg_json, new_version)
 
-        if DEBUG:
+        if settings.DEBUG:
             end_time = time.clock()
             print('Import time for diff between {} and {} was {} seconds'.format(left_version, right_version,
                 end_time - start_time))

--- a/eregs_core/management/commands/import_reg.py
+++ b/eregs_core/management/commands/import_reg.py
@@ -1,37 +1,37 @@
 import os
-import json
 import glob
+import time
 
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
-from lxml import etree
-from itertools import permutations
 
-from eregs_core.models import RegNode
-from eregs_core.utils import xml_to_json
-from eregs import local_settings
-
-import time
 
 class Command(BaseCommand):
-
     help = 'Import the specified regulation into the database.'
 
     def add_arguments(self, parser):
-
-        parser.add_argument('part_number', nargs='?')
+        parser.add_argument('-r', '--regml-root', help='RegML root',
+                            required=True)
+        parser.add_argument('part_number', nargs='+')
 
     def handle(self, *args, **options):
-
         part_number = options['part_number']
-        if part_number is None:
-            print 'Must supply a part number!'
-            exit(0)
+        regml_root = options['regml_root']
 
-        reg_path = os.path.join(local_settings.REGML_ROOT, 'regulation', part_number)
+        if not os.path.isdir(regml_root):
+            raise CommandError('{} is not a directory'.format(regml_root))
+
+        for part_number in options['part_number']:
+            self.handle_part(regml_root, part_number)
+
+    def handle_part(self, regml_root, part_number):
+        reg_path = os.path.join(regml_root, 'regulation', part_number)
         files = glob.glob(reg_path + '/*.xml')
 
-        print 'RegML root in {}'.format(local_settings.REGML_ROOT)
+        if not files:
+            raise ValueError('no files in {}'.format(reg_path))
+
+        print 'RegML root in {}'.format(regml_root)
         print 'Importing the regulation texts for {}'.format(part_number)
         start_time = time.clock()
         for filename in files:
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             print 'Importing {}'.format(doc)
             call_command('import_xml', filename)
 
-        diff_path = os.path.join(local_settings.REGML_ROOT, 'diff', part_number)
+        diff_path = os.path.join(regml_root, 'diff', part_number)
         print 'Importing diffs between every pair of notices in {}'.format(part_number)
         files = glob.glob(diff_path + '/*.xml')
 

--- a/eregs_core/management/commands/import_xml.py
+++ b/eregs_core/management/commands/import_xml.py
@@ -127,4 +127,4 @@ def insert_all(node, version):
                 recursive_insert(child, version)
 
     recursive_insert(node, version)
-    RegNode.objects.bulk_create(result_nodes)
+    RegNode.objects.bulk_create(result_nodes, batch_size=100)


### PR DESCRIPTION
This change modifies how the `import_reg` management command works by removing a dependence on a nonexistent `local_settings.py` file and instead using an explicit command-line option, e.g.

```sh
./manage.py import_reg -r ../regulations-xml 1013
```

This makes the source of regulations more explicit and removes a setup step when using this repository either manually or as part of an automated process.

This change also modifies `import_diff` to use  `django.conf.settings` instead of `eregs.local_settings` to check the `DEBUG` flag.

It also fixes the passing of multiple regulations on the command line, e.g.

```sh
./manage.py import_reg -r ../regulations-xml 1003 1005 1013
```

Finally, it also modifies the `bulk_create` call in `import_xml` to use a batch size of 100; by default Django uses only a single query to insert but if the amount of data to insert is excessive this can fail.
By setting a (hopefully reasonable) bulk batch size, this will avoid errors when loading large regulations.

## Additions

- New command line parameter for local regulations root.

## Changes

- Fixed support for importing of multiple regulations at once.
- Make `bulk_create` in `import_xml` use a batch size to support larger input files.

## Testing

- Try the above command lines.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
