### PR TITLE
add some functions to RegNode to extract left/right versions

### DIFF
--- a/eregs_core/models.py
+++ b/eregs_core/models.py
@@ -264,6 +264,20 @@ class RegNode(models.Model, GenericNodeMixin):
             return ''
 
     @property
+    def left_version(self):
+        if self.reg_version.left_version is not None:
+            return self.reg_version.left_version
+        else:
+            return ''
+
+    @property
+    def right_version(self):
+        if self.reg_version.right_version is not None:
+            return self.reg_version.right_version
+        else:
+            return ''
+
+    @property
     def marker_type(self):
         marker = self.marker.replace('(', '')
         marker = marker.replace(')', '')
@@ -712,6 +726,8 @@ class Section(RegNode):
             diff = difflib.ndiff(left_text, right_text)
             text = merge_text_diff(diff)
             return text
+        else:
+            return self.subject
 
 
 class Paragraph(RegNode):
@@ -781,7 +797,10 @@ class Paragraph(RegNode):
 
     @property
     def paragraph_title(self):
-        return self.get_child('title/regtext').text
+        if self.get_child('title/regtext') is not None:
+            return self.get_child('title/regtext').text
+        else:
+            return ''
 
     @property
     def regtext(self):
@@ -999,6 +1018,9 @@ class DiffNode(RegNode):
 
     # left_version = models.CharField(max_length=250)
     # right_version = models.CharField(max_length=250)
+
+    class Meta:
+        proxy = True
 
     @property
     def left_version(self):


### PR DESCRIPTION
This PR adds a few functions to RegNode that extract left and right versions of a node, if they exist. This is necessary for displaying diffs.

## Additions

Two functions added in `RegNode`: `left_version` and `right_version`.

## Testing

Diffs loaded into the database should display correctly.

## Review

@chosak 

[Preview this PR without the whitespace changes](?w=0)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
