### PR TITLE
Add missing migration due to #40

### DIFF
--- a/eregs_core/migrations/0012_diffnode_is_proxy_model.py
+++ b/eregs_core/migrations/0012_diffnode_is_proxy_model.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('eregs_core', '0011_tocsubpartentry'),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name='DiffNode',
+        ),
+        migrations.CreateModel(
+            name='DiffNode',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('eregs_core.regnode',),
+        ),
+    ]


### PR DESCRIPTION
PR #40 modified the `eregs_core.DiffNode` class to be a proxy model, which required a new migration. This change adds that missing migration, which effectively deletes and recreates the table for that model. This will result in deleting existing `DiffNode` content in your DB.

## Additions

- Adds missing migration `eregs_core.0012`.

## Testing

- Run all migrations backwards and forwards:

```sh
$ ./manage.py migrate eregs_core
$ ./manage.py migrate eregs_core zero
$ ./manage.py migrate eregs_core
```

- Confirm that no new migrations are needed:

```sh
$ ./manage.py makemigrations
No changes detected
```

## Notes

- @grapesmoker before this app goes live it'd be good to wipe out and recreate migrations from scratch. Unless you disagree I don't think this history really serves any useful purpose.
- @willbarton I was considering copying over the "detect missing migrations" test from cfgov-refresh but wasn't sure if there was an easier way to duplicate. Do you think that might make a nice PyPI package somehow?

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests