### PR TITLE
Cleanup setup.py, install only eregs_core

### DIFF
--- a/eregs/settings.py
+++ b/eregs/settings.py
@@ -58,7 +58,7 @@ MIDDLEWARE_CLASSES = (
     #'django.middleware.common.CommonMiddleware',
 )
 
-ROOT_URLCONF = 'eregs.urls'
+ROOT_URLCONF = 'eregs_core.urls'
 
 TEMPLATES = [
     {

--- a/eregs/urls.py
+++ b/eregs/urls.py
@@ -1,39 +1,7 @@
-"""django_skeleton URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.8/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Add an import:  from blog import urls as blog_urls
-    2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
-"""
 from django.conf.urls import include, url
-from django.contrib import admin
-from django.views.decorators.csrf import csrf_exempt
-from eregs_core.views import *
+
+from eregs_core import urls as eregs_core_urls
 
 urlpatterns = [
-    # url(r'^admin/', include(admin.site.urls)),
-    url(r'^$', main),
-    url(r'^(?P<part_number>[\d]{4})', regulation_main),
-    url(r'^regulation/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', regulation),
-    url(r'^diff_redirect/(?P<left_version>[\d]+-[\d]+)/(?P<left_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/', diff_redirect),
-    url(r'^search/$', search),
-    url(r'^diff/(?P<left_version>[\d]+-[\d]+)/(?P<left_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/'
-        r'(?P<right_version>[\d]+-[\d]+)/(?P<right_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', diff),
-    url(r'^partial/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', regulation_partial),
-    url(r'^partial/sxs/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', sxs_partial),
-    url(r'^partial/sidebar/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', sidebar_partial),
-    url(r'^partial/definition/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', definition_partial),
-    url(r'^partial/search/$', search_partial),
-    #url(r'^interpretations/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', interpretations),
-    #url(r'^api/regulation/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', regulation_json),
-    #url(r'^api/meta/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})$', meta_json),
-    #url(r'^api/toc/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})$', toc_json)
+    url(r'^$', include(eregs_core_urls, namespace='eregs')),
 ]

--- a/eregs_core/urls.py
+++ b/eregs_core/urls.py
@@ -1,0 +1,28 @@
+from django.conf.urls import url
+
+from eregs_core.views import (
+    definition_partial, diff, diff_redirect, main, regulation, regulation_main,
+    regulation_partial, search, search_partial, sidebar_partial, sxs_partial
+)
+
+
+urlpatterns = [
+    url(r'^$', main),
+    url(r'^(?P<part_number>[\d]{4})', regulation_main),
+    url((
+        r'^regulation/'
+        '(?P<version>[\d]+-[\d]+)/'
+        '(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/'
+        '(?P<node>.*)$'
+    ), regulation),
+    url(r'^diff_redirect/(?P<left_version>[\d]+-[\d]+)/(?P<left_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/', diff_redirect),
+    url(r'^search/$', search),
+    url(r'^diff/(?P<left_version>[\d]+-[\d]+)/(?P<left_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/'
+        r'(?P<right_version>[\d]+-[\d]+)/(?P<right_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', diff),
+    url(r'^partial/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', regulation_partial),
+    url(r'^partial/sxs/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', sxs_partial),
+    url(r'^partial/sidebar/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', sidebar_partial),
+    url(r'^partial/definition/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', definition_partial),
+    url(r'^partial/search/$', search_partial),
+]
+

--- a/eregs_core/views.py
+++ b/eregs_core/views.py
@@ -13,7 +13,9 @@ from api import *
 import json
 import time
 
+
 from dateutil import parser as dt_parser
+
 
 
 def regulation(request, version, eff_date, node):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from distutils.core import setup
-from setuptools import find_packages
 
 
 install_requires = (
@@ -9,6 +8,12 @@ install_requires = (
     'lxml',
     'python-dateutil',
     'sqlparse',
+)
+
+
+setup_requires = (
+    'cfgov_setup==1.2',
+    'setuptools-git-version==1.0.3',
 )
 
 
@@ -22,16 +27,16 @@ testing_extras = (
 
 setup(
     name='eregs',
-    version='0.0.1',
-    author='Jerry Vinokurov and Chris Contolini',
-    author_email='yury.vinokurov@cfpb.gov',
-    packages=find_packages(),
+    version_format='{tag}.dev{commitcount}+{gitsha}',
+    author='CFPB',
+    author_email='tech@cfpb.gov',
+    packages=['eregs_core'],
     url='https://github.com/cfpb/eregs-2.0',
-    license='MIT',
+    license='CC0',
     description='The new version of eRegs.',
     include_package_data=True,
     install_requires=install_requires,
-    setup_requires=['cfgov_setup==1.2'],
+    setup_requires=setup_requires,
     frontend_build_script='setup.sh',
     extras_require={
         'testing': testing_extras,


### PR DESCRIPTION
This change modifies how `setup.py` works and how this package gets installed via `pip install`. Instead of installing two separate packages (`eregs_core`, containing views and models, and `eregs`, containing URLs and settings), this app now only installs a single `eregs_core` package
that contains models, views, and URLs. This makes the code more self-contained and is more consistent with how users of this package might expect it to be used.

This change also modifies the author and license in `setup.py` to be more consistent with CFPB standards (using CC0 instead of MIT). It also enables the use of [setuptools-git-version](https://pypi.python.org/pypi/setuptools-git-version/1.0.3) to more easily set package versions for releases.

This addresses issues #46 and #47.

## Additions

- Add use of setuptools-git-version to automatically set package version from git.

## Changes

- Modified `setup.py` to properly list author and CC0 license.

## Testing

- Run `pip install git+https://github.com/cfpb/eregs-2.0.git@slimmer-setup.py#egg=eregs` and note that only a single `eregs_core` package is installed, properly containing its URLs.

## Notes

- Note that this will require a change to how projects like [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/) incorporate this project's URLs.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)