### PR TITLE
check for missing regLetter and return cfr_section if it's missing

### DIFF
--- a/eregs_core/models.py
+++ b/eregs_core/models.py
@@ -319,7 +319,11 @@ class Preamble(RegNode):
 
     @property
     def reg_letter(self):
-        return self.get_child('regLetter/regtext').text
+        reg_letter = self.get_child('regLetter')
+        if reg_letter is not None:
+            return reg_letter.get_child('regtext').text
+        else:
+            return self.cfr_section
 
     @property
     def cfr_title(self):

--- a/eregs_core/models.py
+++ b/eregs_core/models.py
@@ -323,7 +323,7 @@ class Preamble(RegNode):
         if reg_letter is not None:
             return reg_letter.get_child('regtext').text
         else:
-            return self.cfr_section
+            return None
 
     @property
     def cfr_title(self):

--- a/eregs_core/templates/eregs_core/main.html
+++ b/eregs_core/templates/eregs_core/main.html
@@ -37,7 +37,7 @@ Main
                                     <a href="/{{ regulation.cfr_section }}">
                                         <span class="title-num">{{regulation.cfr_section}}</span>
                                         <div class="reg-sub-title">
-                                            <span class="reg-letter">Regulation {{regulation.reg_letter}}</span>
+                                            <span class="reg-letter">Regulation {{regulation.reg_letter|default:regulation.cfr_section}}</span>
                                             <!--<span class="reg-title">{{regulation.children.1.children.0}}</span>-->
                                         </div>
                                         <span class="cf-icon cf-icon-right-round"></span>

--- a/eregs_core/templates/eregs_core/regulation_header.html
+++ b/eregs_core/templates/eregs_core/regulation_header.html
@@ -8,7 +8,7 @@
                     </a>
                 </h1>
                 <h2 class="reg-title">
-                    <a href="#">{{ meta.cfr_title }} CFR Part {{ meta.cfr_section }} (Regulation {{ meta.reg_letter }})</a>
+                    <a href="#">{{ meta.cfr_title }} CFR Part {{ meta.cfr_section }} (Regulation {{ meta.reg_letter|default:meta.cfr_section}})</a>
                 </h2>
             </div>
             <nav class="app-nav">

--- a/eregs_core/views.py
+++ b/eregs_core/views.py
@@ -17,7 +17,6 @@ import time
 from dateutil import parser as dt_parser
 
 
-
 def regulation(request, version, eff_date, node):
 
     if request.method == 'GET':
@@ -347,21 +346,19 @@ def main(request):
 
     if request.method == 'GET':
 
-        # meta = Preamble.objects.filter(tag='preamble')
         reg_versions = Version.objects.exclude(version=None)
         meta = [r for r in Preamble.objects.filter(tag='preamble', reg_version__in=reg_versions)]
-        # meta = sorted(meta, key=lambda x: x.reg_letter, reverse=True)
 
         regs_meta = []
         reg_parts = set()
 
         for item in meta:
             item.get_descendants(auto_infer_class=False)
-            if item.reg_letter not in reg_parts:
+            if (item.cfr_title, item.cfr_section) not in reg_parts:
                 regs_meta.append(item)
-                reg_parts.add(item.reg_letter)
+                reg_parts.add((item.cfr_title, item.cfr_section))
 
-        regs_meta = sorted(regs_meta, key=lambda x: int(x.cfr_section))
+        regs_meta = sorted(regs_meta, key=lambda x: (int(x.cfr_title), int(x.cfr_section)))
         fdsys = RegNode.objects.filter(tag='fdsys')
 
         return render_to_response('eregs_core/main.html', {


### PR DESCRIPTION
This addresses issue #50; the schema allows for `regLetter` to be optional rather than required, as it's a concept that may be specific to CFPB regs and not regs in general. Thus, the code should treat the element as optional and not assume it will exist.

## Changes

If `regLetter` is absent from an imported reg, a call to the `reg_letter` property will now just return the CFR part number.

## Testing

You should be able to import any reg that has a missing `regLetter` element in its preamble and be able to view it; where a regulation letter would exist, you will instead see the CFR section (e.g. `1003` instead of `C`).

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
