### PR TITLE
Shorten version fields to 64 characters

### DIFF
--- a/eregs_core/migrations/0007_auto_20170510_1949.py
+++ b/eregs_core/migrations/0007_auto_20170510_1949.py
@@ -17,9 +17,9 @@ class Migration(migrations.Migration):
             name='Version',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('version', models.CharField(max_length=250, null=True)),
-                ('left_version', models.CharField(max_length=250, null=True)),
-                ('right_version', models.CharField(max_length=250, null=True)),
+                ('version', models.CharField(max_length=64, null=True)),
+                ('left_version', models.CharField(max_length=64, null=True)),
+                ('right_version', models.CharField(max_length=64, null=True)),
             ],
         ),
         migrations.CreateModel(

--- a/eregs_core/models.py
+++ b/eregs_core/models.py
@@ -19,9 +19,9 @@ from itertools import product
 
 class Version(models.Model):
 
-    version = models.CharField(max_length=250, null=True)
-    left_version = models.CharField(max_length=250, null=True)
-    right_version = models.CharField(max_length=250, null=True)
+    version = models.CharField(max_length=64, null=True)
+    left_version = models.CharField(max_length=64, null=True)
+    right_version = models.CharField(max_length=64, null=True)
 
     @property
     def right_doc_number(self):


### PR DESCRIPTION
The version fields on the `eregs_core.Version` model are unnecessarily large, at 250 characters. This causes a problem when using the default settings on MySQL 5.7, where indexes can have a maximum length of 1000 bytes. Using the `utf8` character set (the default), with three bytes
per character, the `eregs_core__version_idx` index created in `eregs_core.migrations.0010` far exceeds this limit. Using a character set of `utf8mb4` makes it even worse.

I implemented this change as a retroactive change to `migrations.0007` instead of as a new migration due to the pre-release state of this repo.

Testing this against e.g. Reg C, the longest version field is only 21 characters (something like `2011-31712:2011-12-30`, which is the standard format). Even for something like Reg Z where we might have longer versions (like `2016-06-27:2016-14782_20170101`), 64 characters
should still be sufficient.

## Changes

- Shorten fields on `Version`.

## Testing

- Try migrating a new database and loading some content.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests