### PR TITLE
Disable JavaScript

### DIFF
--- a/eregs_core/templates/eregs_core/base.html
+++ b/eregs_core/templates/eregs_core/base.html
@@ -16,7 +16,7 @@
 
 
         <link rel="stylesheet" href="{% static 'regulations/css/style.css' %}">
-        <script src="{% static "regulations/js/built/regulations.js" %}"></script>
+        <!-- <script src="{% static "regulations/js/built/regulations.js" %}"></script> -->
 
     </head>
     <body>


### PR DESCRIPTION
This commit disables JavaScript on this app's pages by removing (commenting out) the inclusion of the JS library.

While this app is in pre-release mode and is still being developed, removing the use of JS will help to simplify testing. The app should also support non-JS users as well, so removing JS for now will help to guarantee that all functionality works when JS is disabled.

## Removals

- JS, from the base template.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] Visually tested in supported browsers and devices