### PR TITLE
Convert hardcoded URLs to dynamic ones

### DIFF
--- a/eregs_core/eregs_tests/test_model_functions.py
+++ b/eregs_core/eregs_tests/test_model_functions.py
@@ -107,7 +107,7 @@ class ModelFunctionsTest(TestCase):
         self.assertEqual(preamble.effective_date, '2011-12-30')
         self.assertEqual(preamble.document_number, '2011-31712')
         self.assertEqual(preamble.cfr_url, 'https://www.federalregister.gov/articles/2011/12/19/2011-31712/home-mortgage-disclosure-regulation-c')
-        self.assertEqual(preamble.reg_url, 'regulation/2011-31712/2011-12-30/1003-1')
+        self.assertEqual(preamble.reg_url, '/regulation/2011-31712/2011-12-30/1003-1')
 
     def test_fdsys_functions(self):
 

--- a/eregs_core/templates/eregs_core/main.html
+++ b/eregs_core/templates/eregs_core/main.html
@@ -34,7 +34,7 @@ Main
                         <ul class="reg-list">
                             {% for regulation in preamble %}
                                 <li>
-                                    <a href="/{{ regulation.cfr_section }}">
+                                    <a href="{% url 'eregs_regulation_main' regulation.cfr_section %}">
                                         <span class="title-num">{{regulation.cfr_section}}</span>
                                         <div class="reg-sub-title">
                                             <span class="reg-letter">Regulation {{regulation.reg_letter|default:regulation.cfr_section}}</span>

--- a/eregs_core/templates/eregs_core/regulation_header.html
+++ b/eregs_core/templates/eregs_core/regulation_header.html
@@ -1,9 +1,12 @@
+{% load staticfiles %}
+
+
 {% block regulation_header %}
     <header if="site-header" class="reg-header chrome-header" role="banner">
         <div class="main-head">
             <div class="title">
                 <h1 class="site-title">
-                    <a href="/">
+                    <a href="{% url 'eregs_main' %}">
                         <span class="e">e</span>Regulations
                     </a>
                 </h1>
@@ -18,14 +21,14 @@
                 </a>
                 <ul class="app-nav-list">
                     <li class="app-nav-list-item">
-                        <a href="/">Regulations</a>
+                        <a href="{% url 'eregs_main' %}">Regulations</a>
                     </li>
                     <li class="app-nav-list-item">
                         <a href="/about">About</a>
                     </li>
                     <li class="app-nav-list-item logo-list-item">
-                        <a href="http://consumerfinance.gov">
-                            <img src="/static/eregsip/logo.png" class="logo"
+                        <a href="https://www.consumerfinance.gov">
+                            <img src="{% static 'eregsip/logo.png' %}" class="logo"
                             alt="Consumer Financial Protection Bureau" width="151">
                         </a>
                     </li>

--- a/eregs_core/templates/eregs_core/right_sidebar.html
+++ b/eregs_core/templates/eregs_core/right_sidebar.html
@@ -1,3 +1,6 @@
+{% load staticfiles %}
+
+
 <section id="sxs-list" class="regs-meta">
     <header id="sxs-expandable-header" class="expandable sxs-expand group has-content" data-expandable="sxs-expandable">
         <h4 tabindex="0">Section-by-section Analysis</h4>
@@ -76,7 +79,7 @@
                     </div>
                 </li>
                 <li>
-                    <img src="/static/regulations/img/supplement-sample.png" class="block-image">
+                  <img src="{% static 'regulations/img/supplement-sample.png' %}" class="block-image">
                     Inline interpretations/commentary from Supplement I
                 </li>
             </ul>

--- a/eregs_core/templates/eregs_core/search.html
+++ b/eregs_core/templates/eregs_core/search.html
@@ -5,7 +5,7 @@
         <h2 class="toc-type">Search</h2>
     </div>
     <div class="drawer-content">
-        <form action="/search/" method="get" role="search" _lpchecked="1">
+        <form action="{% url 'eregs_search' %}" method="get" role="search" _lpchecked="1">
             <div class="search-box">
                 <input type="text" name="q" value="" id="search-input"><button type="submit">
                     <i class="cf-icon cf-icon-search"></i>

--- a/eregs_core/templates/eregs_core/search_results.html
+++ b/eregs_core/templates/eregs_core/search_results.html
@@ -18,10 +18,10 @@
     </section>
     <footer class="search-nav">
         {% if prev_page %}
-            <a class="previous" href="/partial/search/?q={{ search_term }}&version={{ version }}&page={{ prev_page }}"><span class="cf-icon cf-icon-left"></span>Previous 10 Results</a>
+          <a class="previous" href="{% url 'eregs_partial_search' %}?q={{ search_term }}&version={{ version }}&page={{ prev_page }}"><span class="cf-icon cf-icon-left"></span>Previous 10 Results</a>
         {% endif %}
         {% if next_page %}
-            <a class="next" href="/partial/search/?q={{ search_term }}&version={{ version }}&page={{ next_page }}"><span class="cf-icon cf-icon-right"></span>Next 10 Results</a>
+          <a class="next" href="{% url 'eregs_partial_search' %}?q={{ search_term }}&version={{ version }}&page={{ next_page }}"><span class="cf-icon cf-icon-right"></span>Next 10 Results</a>
         {% endif %}
         <div class="pager">Page {{ page }} of {{ total_pages }}</div>
     </footer>

--- a/eregs_core/templates/eregs_core/timeline.html
+++ b/eregs_core/templates/eregs_core/timeline.html
@@ -25,7 +25,7 @@
                     current
                 {% endif %}"
                     data-base-version="{{ preamble.version }}">
-                    <a href="/{{ preamble.reg_url }}" class="version-link" data-version="{{ preamble.version }}"
+                    <a href="{{ preamble.reg_url }}" class="version-link" data-version="{{ preamble.version }}"
                             id="link-{{ preamble.version }}">
                         <span class="version-date">{{ preamble.effective_date|effective_date }}</span>
                     </a>
@@ -43,7 +43,7 @@
                         <div class="diff-selector group">
                             <h4 class="compare-title">Compare this with</h4>
                             <div class="select-content">
-                                <form action="/diff_redirect/{{ preamble.document_number }}/{{ preamble.effective_date }}"
+                                <form action="{% url 'eregs_diff_redirect' preamble.document_number preamble.effective_date %}"
                                       method="GET">
                                     <select name="new_version" onchange="this.form.submit()">
                                         <option value="default" disabled="disabled" selected="selected">
@@ -65,7 +65,7 @@
                                 <div class="timeline-content-wrap">
                                     <h4 class="compare-title">Compare this with</h4>
                                     <a class="stop-button" data-version="{{ preamble.version }}"
-                                       href="/{{ preamble.reg_url }}">Stop Comparing</a>
+                                       href="{{ preamble.reg_url }}">Stop Comparing</a>
                                 </div>
                             {% endif %}
                         {% endif %}

--- a/eregs_core/templates/eregs_core/toc_entry.html
+++ b/eregs_core/templates/eregs_core/toc_entry.html
@@ -2,11 +2,11 @@
         {% if entry.action == "modified" %}class="modified"{% endif %}>
     {% if entry.tag == "tocSecEntry" or entry.tag == "tocAppEntry" or entry.tag == "tocInterpEntry" %}
         {% if mode == 'reg' or mode == 'landing' or mode == 'search' %}
-            <a href="/regulation/{{ meta.document_number }}/{{ meta.effective_date }}/{{ entry.target }}"
+          <a href="{% url 'eregs_regulation' meta.document_number meta.effective_date entry.target %}"
                 data-section-id="{{ entry.target }}" id="nav-{{ entry.target }}"
                 data-doc-number="{{ meta.document_number }}" data-version="{{ meta.effective_date }}">
         {% elif mode == 'diff' %}
-            <a href="/diff/{{ meta.left_document_number}}/{{ meta.left_effective_date}}/{{ meta.right_document_number }}/{{ meta.right_effective_date }}/{{ entry.target }}"
+          <a href="{% url 'eregs_diff' meta.left_document_number meta.left_effective_date meta.right_document_number meta.right_effective_dat entry.target %}"
                 data-section-id="{{ entry.target }}" id="nav-{{ entry.target }}"
                 data-doc-number="{{ meta.left_document_number }}" data-version="{{ meta.left_effective_date }}">
         {% endif %}

--- a/eregs_core/urls.py
+++ b/eregs_core/urls.py
@@ -7,24 +7,48 @@ from eregs_core.views import (
 
 
 urlpatterns = [
-    url(r'^$', main),
-    url(r'^(?P<part_number>[\d]{4})', regulation_main),
+    url(r'^$', main, name='eregs_main'),
+    url(r'^(?P<part_number>[\d]{4})',
+        regulation_main,
+        name='eregs_regulation_main'),
     url((
-        r'^regulation/'
-        '(?P<version>[\d]+-[\d]+)/'
-        '(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/'
-        '(?P<node>.*)$'
-    ), regulation),
-    url(r'^diff_redirect/(?P<left_version>[\d]+-[\d]+)/(?P<left_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/', diff_redirect),
-    url(r'^search/$', search),
-    url(r'^diff/(?P<left_version>[\d]+-[\d]+)/(?P<left_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/'
-        r'(?P<right_version>[\d]+-[\d]+)/(?P<right_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', diff),
+            r'^regulation/'
+            '(?P<version>[\d]+-[\d]+)/'
+            '(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/'
+            '(?P<node>.*)$'
+        ),
+        regulation,
+        name='eregs_regulation'),
+    url((
+            r'^diff_redirect/'
+            '(?P<left_version>[\d]+-[\d]+)/'
+            '(?P<left_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/'
+        ),
+        diff_redirect,
+        name='eregs_diff_redirect'),
+    url(r'^search/$', search, name='eregs_search'),
+    url((
+            r'^diff/(?P<left_version>[\d]+-[\d]+)/'
+            '(?P<left_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/'
+            '(?P<right_version>[\d]+-[\d]+)/'
+            '(?P<right_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/'
+            '(?P<node>.*)$'
+        ),
+        diff,
+        name='eregs_diff'),
     url(r'^partial/diff/(?P<left_version>[\d]+-[\d]+)/(?P<left_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/'
         r'(?P<right_version>[\d]+-[\d]+)/(?P<right_eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', diff_partial),
     url(r'^partial/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', regulation_partial),
-    url(r'^partial/sxs/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', sxs_partial),
+    url((
+        r'^partial/sxs/'
+        '(?P<version>[\d]+-[\d]+)/'
+        '(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/'
+        '(?P<node>.*)$'
+        ),
+        sxs_partial,
+        name='eregs_sxs_partial'),
     url(r'^partial/sidebar/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', sidebar_partial),
     url(r'^partial/definition/(?P<version>[\d]+-[\d]+)/(?P<eff_date>[\d]{4}-[\d]{2}-[\d]{2})/(?P<node>.*)$', definition_partial),
-    url(r'^partial/search/$', search_partial),
+    url(r'^partial/search/$', search_partial, name='eregs_partial_search'),
 ]
 


### PR DESCRIPTION
This change removes usage of hardcoded URLs in favor of using Django's `django.core.urlresolvers.reverse` and `{% url %}` template tag to better support cases where this app is being deployed under a website's subdirectory.

For example, if this app is deployed under a `/eregs-2.0` subdirectory, regulation URLs should be under `/eregs-2.0/regulation/etc`, and not under a hardcoded `/regulation/etc`.

In addition, a couple of hardcoded `/static` references in templates have been converted to use of Django's `{% static %}` tag, for a similar reason.

## Changes

- Hardcoded URLs instead now use `django.core.urlresolvers.reverse` and `{% url %}`.
- Hardcoded references to `/static` now use `{% static %}`.

## Testing

- All existing unit tests continue to pass, and working site functionality continues to do so.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] Visually tested in supported browsers and devices