### PR TITLE
Cleanup main view and add tests

### DIFF
--- a/data/header-only.xml
+++ b/data/header-only.xml
@@ -1,0 +1,24 @@
+<regulation xmlns="eregs">
+  <fdsys>
+    <cfrTitleNum>99</cfrTitleNum>
+    <cfrTitleText>TESTING</cfrTitleText>
+    <volume>99</volume>
+    <date>2017-01-01</date>
+    <originalDate>2017-01-01</originalDate>
+    <title>TEST</title>
+  </fdsys>
+  <preamble>
+    <agency>Bureau of Consumer Financial Protection</agency>
+    <regLetter>TEST</regLetter>
+    <cfr>
+      <title>123</title>
+      <section>4567</section>
+    </cfr>
+    <documentNumber>9999-99999</documentNumber>
+    <effectiveDate>2017-01-01</effectiveDate>
+    <federalRegisterURL>https://www.federalregister.gov/testing</federalRegisterURL>
+  </preamble>
+  <part label="9999">
+    <content></content>
+  </part>
+</regulation>

--- a/eregs_core/tests/test_urls.py
+++ b/eregs_core/tests/test_urls.py
@@ -1,0 +1,7 @@
+from unittest import TestCase
+
+
+class UrlPatternsTestCase(TestCase):
+    def test_urlpatterns_import_succeeds(self):
+        from eregs_core.urls import urlpatterns
+        self.assertTrue(urlpatterns)

--- a/eregs_core/tests/views/test_main.py
+++ b/eregs_core/tests/views/test_main.py
@@ -1,0 +1,32 @@
+import os
+
+from django.conf import settings
+from django.core.management import call_command
+from django.test import RequestFactory, TestCase
+
+from eregs_core.views.main import MainView
+
+
+class TestMainView(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.view = MainView.as_view()
+
+    def test_view_renders_without_any_data(self):
+        request = self.factory.get('/')
+        response = self.view(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_post_to_view_returns_method_not_allowed(self):
+        request = self.factory.post('/')
+        response = self.view(request)
+        self.assertEqual(response.status_code, 405)
+
+    def test_view_renders_with_data(self):
+        filename = os.path.join(settings.DATA_DIR, 'header-only.xml')
+        call_command('import_xml', filename)
+
+        request = self.factory.get('/')
+        response = self.view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Regulation TEST')

--- a/eregs_core/tests/views/test_views.py
+++ b/eregs_core/tests/views/test_views.py
@@ -6,7 +6,7 @@ from django.test import RequestFactory, TestCase
 from mock import Mock, patch
 
 from eregs_core.views import (
-    definition_partial, main, regulation, regulation_main, regulation_partial,
+    definition_partial, regulation, regulation_main, regulation_partial,
     search, search_partial, sidebar_partial
 )
 
@@ -44,10 +44,6 @@ class TestViews(TestCase):
             self.effective_date,
             '1003-A'
         )
-        self.assertEquals(response.status_code, 200)
-
-    def test_view_main(self):
-        response = main(self.request())
         self.assertEquals(response.status_code, 200)
 
     def test_view_regulation(self):

--- a/eregs_core/urls.py
+++ b/eregs_core/urls.py
@@ -1,13 +1,15 @@
 from django.conf.urls import url
 
 from eregs_core.views import (
-    definition_partial, diff, diff_partial, diff_redirect, main, regulation, regulation_main,
-    regulation_partial, search, search_partial, sidebar_partial, sxs_partial
+    definition_partial, diff, diff_partial, diff_redirect, regulation,
+    regulation_main, regulation_partial, search, search_partial,
+    sidebar_partial, sxs_partial
 )
+from eregs_core.views.main import MainView
 
 
 urlpatterns = [
-    url(r'^$', main, name='eregs_main'),
+    url(r'^$', MainView.as_view(), name='eregs_main'),
     url(r'^(?P<part_number>[\d]{4})',
         regulation_main,
         name='eregs_regulation_main'),

--- a/eregs_core/views/__init__.py
+++ b/eregs_core/views/__init__.py
@@ -1,20 +1,13 @@
-from django.shortcuts import render, render_to_response
+from django.shortcuts import render_to_response
 from django.template.loader import render_to_string
-from django.http import HttpResponse, HttpResponseRedirect, Http404
-from django.views.decorators.csrf import csrf_exempt
+from django.http import HttpResponse, HttpResponseRedirect
 from django.views.decorators.cache import never_cache
 
 from haystack.query import SearchQuerySet
 
-from models import *
-from utils import *
-from api import *
-
-import json
-import time
-
-
-from dateutil import parser as dt_parser
+from eregs_core.models import *
+from eregs_core.utils import *
+from eregs_core.api import *
 
 
 def regulation(request, version, eff_date, node):
@@ -340,28 +333,3 @@ def regulation_main(request, part_number):
                 'landing_page': landing_page,
                 'landing_page_sidebar': landing_page_sidebar,
             })
-
-
-def main(request):
-
-    if request.method == 'GET':
-
-        reg_versions = Version.objects.exclude(version=None)
-        meta = [r for r in Preamble.objects.filter(tag='preamble', reg_version__in=reg_versions)]
-
-        regs_meta = []
-        reg_parts = set()
-
-        for item in meta:
-            item.get_descendants(auto_infer_class=False)
-            if (item.cfr_title, item.cfr_section) not in reg_parts:
-                regs_meta.append(item)
-                reg_parts.add((item.cfr_title, item.cfr_section))
-
-        regs_meta = sorted(regs_meta, key=lambda x: (int(x.cfr_title), int(x.cfr_section)))
-        fdsys = RegNode.objects.filter(tag='fdsys')
-
-        return render_to_response('eregs_core/main.html', {
-            'preamble': regs_meta,
-            'fdsys': fdsys,
-        })

--- a/eregs_core/views/main.py
+++ b/eregs_core/views/main.py
@@ -1,0 +1,38 @@
+from django.views.generic import TemplateView
+
+from eregs_core.models import Preamble, Version
+
+
+class MainView(TemplateView):
+    template_name = 'eregs_core/main.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(MainView, self).get_context_data(**kwargs)
+
+        reg_versions = Version.objects.exclude(version=None)
+        meta = [
+            r for r in Preamble.objects.filter(
+                tag='preamble',
+                reg_version__in=reg_versions
+            )
+        ]
+
+        regs_meta = []
+        reg_parts = set()
+
+        for item in meta:
+            item.get_descendants(auto_infer_class=False)
+            if (item.cfr_title, item.cfr_section) not in reg_parts:
+                regs_meta.append(item)
+                reg_parts.add((item.cfr_title, item.cfr_section))
+
+        regs_meta = sorted(
+            regs_meta,
+            key=lambda x: (int(x.cfr_title), int(x.cfr_section))
+        )
+
+        context.update({
+            'preamble': regs_meta,
+        })
+
+        return context


### PR DESCRIPTION
This commit converts the landing page (main view) into a Django class-based view and moves it into its own module. It also adds various unit tests to cover this view.

This is a partial fix to the issue in #44 where non-GET (e.g. POST) requests to this view would raise a 500 error.

This commit adds a dummy `data/header-only.xml` RegML file (which validates against the schema) that can be used for simple testing of this view only. The new unit tests for this view validate that it works with no data or with data loaded.

This commit also adds a simple unittest against `eregs_core.urls` to ensure that the URLs module can be imported (to protect against syntax errors which would otherwise not be discovered via the test suite).

## Additions

- New test cases against the main view and the urls.

## Changes

- Moves `eregs_core.views.main` into a Django class-based view at `eregs_core.views.main.MainView`.

## Testing

- Run unit tests with e.g. `tox -e dj18`.
- Run a local server with `./manage.py runserver` and navigate to http://localhost:8000.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
