### PR TITLE
configure travis to generate wheel artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ nodejs: 6
 services:
 - mysql
 before_install:
-- rm -rf ~/.nvm
-- curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.30.2/install.sh | bash
-- source ~/.nvm/nvm.sh
-- nvm install 6
 - npm install -g npm
 - ./.travis-install-mysql-5.7.sh
 - mysql -uroot -e "CREATE USER 'eregs'@'localhost' IDENTIFIED BY 'eregs';"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,34 @@
 sudo: required
-
 language: python
 cache: pip
-
 python:
-  - 2.7
-
+- 2.7
+nodejs: 6
 services:
-  - mysql
-
+- mysql
 before_install:
-  - rm -rf ~/.nvm
-  - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.30.2/install.sh | bash
-  - source ~/.nvm/nvm.sh
-  - nvm install 6
-  - npm install -g npm
-  - ./.travis-install-mysql-5.7.sh
-  - mysql -uroot -e "CREATE USER 'eregs'@'localhost' IDENTIFIED BY 'eregs';"
-  - mysql -uroot -e "GRANT ALL PRIVILEGES ON \`test_%\`.* TO 'eregs'@'localhost';"
-
-install:
-  pip install tox coveralls
-
+- rm -rf ~/.nvm
+- curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.30.2/install.sh | bash
+- source ~/.nvm/nvm.sh
+- nvm install 6
+- npm install -g npm
+- ./.travis-install-mysql-5.7.sh
+- mysql -uroot -e "CREATE USER 'eregs'@'localhost' IDENTIFIED BY 'eregs';"
+- mysql -uroot -e "GRANT ALL PRIVILEGES ON \`test_%\`.* TO 'eregs'@'localhost';"
+install: pip install tox coveralls
 before_script:
-  - ./setup.sh
-
+- ./setup.sh
 script:
-  - npm test
-  - TOXENV=dj18 tox
-
-after_success:
-  coveralls
+- npm test
+- TOXENV=dj18 tox
+- python2.7 setup.py bdist_wheel
+after_success: coveralls
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key:
+    secure: UQZ16cdJ48IHL4Ve4oZ9zkKQqRAeDi9wMPb5RJGM3FnoVAONV5lHQTKdH2FulfRvXBa5JK1x5fcjivaKczS0uIDbcyKiKWiMI44xyFl22FLnpq6OWX55TFe8YpF+UFHcB63bej4Nxsicnug/zkW26xS9ZrwMRgz+xjoIDZRmEi5NdDtwIsqClpfFfLm3Kdhs7plYlXi1K2GLUcJY3UVfwvFd6EQhsuAMtwvZ56AaOQiYBCjWTTzXUaYK/ythYMZBIm/rDCDLsItFzdGyIv3IfFyJPzwmITWupJ90FbXiaXqF3eMtbHZa54JMmVkU3smnSgdqvQFDNfOoz+WEdX47IhmNQV5L7QaN0uSXcBmxl6J2ud/bh4024hk60Cey4KPdEv7h8fKPTwe4Uer70b3h6OoL4fmGJM0ny6y6ka0zS1Hq2A/oSJ1bUbmiucFNL1eggCqknFdo45Mc/AVTtDf1wUahUGF07LV+PwaFz5BTPfaIzxJVplJQAQrR8EivWkymLKtPmVduvb11GPLnphdPMvzCqVH+3Gqh0ApH6nhD/AyHij/t1Wj/BcPHtz2FPxkXcHSvTyX49GelXBz9kutBaea+QcCmFZR3YVxZHHtvKDY4IgNLedXjHYVBcKEIOvwYy81rCP+pzImhijeu4TnaHF1DjC2HWMia7kowJiadqi4=
+  file_glob: true
+  file: dist/*.whl
+  on:
+    tags: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include CHANGELOG.md CONTRIBUTING.md LICENSE README.md TERMS.md
-recursive-include eregs_core *.py *.html *.js
+recursive-include eregs_core *.py *.html *.js *.css
 prune eregs_core/static/regulations/js/unittests/coverage

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 
 install_requires = (


### PR DESCRIPTION
This configures Travis so that whenever a new Github 'release' is created, a wheel is generated and attached to the release page. Here's an example of what that looks like, from college-costs: https://github.com/cfpb/college-costs/releases/tag/2.3.9

Some benefits: this should make deployments faster and simpler (since the package will never need to be "built" in Jenkins), and removes the requirement that every app must support whatever Node version that cfgov-refresh depends on.

You can see in optional-public that we've started replacing git checkout URL's with absolute links to the built wheels:  https://github.com/cfpb/cfgov-refresh/blob/master/requirements/optional-public.txt

## Additions

- added a script line that generates a Wheel at the end of the test script, and 
- 'deploy' configuration in .travis.yml, that (on a new release) will attach the wheel to the release page on Github, as [documented here](https://docs.travis-ci.com/user/deployment/releases/)
 
## Changes

- setup.py wasn't responding to bdist_wheel for some reason, I'm not sure-- Switching from distutils to setuptools worked, though

## Testing

- As long as Travis gets to the end of the test script, we should be good.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
